### PR TITLE
Fixing a less than ideal way to locate ModuleManager

### DIFF
--- a/UbioWeldingLtd/DatabaseHandler.cs
+++ b/UbioWeldingLtd/DatabaseHandler.cs
@@ -38,7 +38,7 @@ namespace UbioWeldingLtd
 				Assembly assembly = lAssembly.assembly;
 				System.Version aVersion = assembly.GetName().Version;
 
-				if (assembly.GetName().Name.StartsWith("ModuleManager") &&
+				if (assembly.GetName().Name.Equals("ModuleManager") &&
 						(((_MMAssembly == null) && (aVersion >= Constants.minModuleManagerVersion)) || //first instance of ModuleManager
 						(_MMAssembly.GetName().Version < aVersion)))	//in case was loaded multiple versions of ModuleManager
 				{


### PR DESCRIPTION
That started to bite due the existence of a thingy called ModuleManagerWatchDog